### PR TITLE
Run processes in new process groups, kill process group instead of process

### DIFF
--- a/lib/foreman/engine.rb
+++ b/lib/foreman/engine.rb
@@ -191,14 +191,14 @@ class Foreman::Engine
       @running.each do |pid, (process, index)|
         system "sending #{signal} to #{name_for(pid)} at pid #{pid}"
         begin
-          Process.kill(signal, pid)
+          Process.kill("-#{signal}", pid)
         rescue Errno::ESRCH, Errno::EPERM
         end
       end
     else
       begin
         pids = @running.keys.compact
-        Process.kill signal, *pids unless pids.empty?
+        Process.kill("-#{signal}", *pids) unless pids.empty?
       rescue Errno::ESRCH, Errno::EPERM
       end
     end

--- a/lib/foreman/process.rb
+++ b/lib/foreman/process.rb
@@ -49,9 +49,10 @@ class Foreman::Process
     env    = @options[:env].merge(options[:env] || {})
     output = options[:output] || $stdout
     runner = "#{Foreman.runner}".shellescape
-    
+    pgroup = Foreman.windows? ? :new_pgroup : :pgroup
+
     Dir.chdir(cwd) do
-      Process.spawn env, expanded_command(env), :out => output, :err => output
+      Process.spawn env, expanded_command(env), :out => output, :err => output, pgroup => true
     end
   end
 


### PR DESCRIPTION
This is https://github.com/ddollar/foreman/pull/780 but for this repo, original description below

---

This is https://github.com/ddollar/foreman/pull/723 but rebased against master today. Credit to @davishmcclurg for suggesting those changes in the first place.

>Some processes are getting orphaned when running Foreman with JRuby.
>Creating a new pgroup allows them all to be killed together.
>
>I believe the issue is related to how JRuby handles `Dir.chdir` by
>creating a shell process: `sh -c 'cd /chdir/target; ${command}'`. That
>causes a second process to be created that won't get cleaned up by
>killing the parent.

I think this change also addresses #779.  It makes Foreman match what [Honcho](https://github.com/nickstenning/honcho) does, and Honcho does not exhibit the problem shown in #779.

Close #779 

(Some additional background: There was an earlier PR #528 that did half of what this PR does, https://github.com/ddollar/foreman/issues/525 was closed after that was merged, but then the PR was reverted after a few days, could not find the reason for that).