### PR TITLE
Correctly avoid using `ostruct`

### DIFF
--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -1,4 +1,5 @@
 require "foreman/export"
+require "ostruct"
 require "pathname"
 require "shellwords"
 
@@ -34,7 +35,7 @@ class Foreman::Export::Base
     def @engine.procfile
       Foreman::Export::Base.warn_deprecation!
       @processes.map do |process|
-        Struct.new(
+        OpenStruct.new(
           :name => @names[process],
           :process => process
         )

--- a/lib/foreman/export/base.rb
+++ b/lib/foreman/export/base.rb
@@ -1,5 +1,4 @@
 require "foreman/export"
-require "ostruct"
 require "pathname"
 require "shellwords"
 
@@ -12,6 +11,9 @@ class Foreman::Export::Base
 
   # deprecated
   attr_reader :port
+
+  # deprecated
+  ProcessStruct = Struct.new(:name, :process)
 
   def initialize(location, engine, options={})
     @location  = location
@@ -35,10 +37,7 @@ class Foreman::Export::Base
     def @engine.procfile
       Foreman::Export::Base.warn_deprecation!
       @processes.map do |process|
-        OpenStruct.new(
-          :name => @names[process],
-          :process => process
-        )
+        ProcessStruct.new(@names[process], process)
       end
     end
   end

--- a/spec/foreman/process_spec.rb
+++ b/spec/foreman/process_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'foreman/process'
-require 'ostruct'
 require 'timeout'
 require 'tmpdir'
 

--- a/spec/foreman/process_spec.rb
+++ b/spec/foreman/process_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'foreman/process'
+require 'ostruct'
 require 'timeout'
 require 'tmpdir'
 


### PR DESCRIPTION
...as it no longer will ship with Ruby 3.5

From https://github.com/ddollar/foreman/pull/807

>This change introduces a local Struct, used in a supporting-deprecated use-case part of the code.
>
>**Benefit**: When requiring ostruct, a warning is emitted by Ruby, saying that ostruct will no longer be a standard built-in library in Ruby 3.5.0.
>
> This PR avoids the warning by using a Struct.

Credits to @olleolleolle